### PR TITLE
cleanup, remove OneEuro filter and hadrcoded paths, use NOFC for ctlrs

### DIFF
--- a/NOFC/NOFCv0.3_hdk2.direct.ceiling.json
+++ b/NOFC/NOFCv0.3_hdk2.direct.ceiling.json
@@ -1,0 +1,114 @@
+{
+	"description": "Version 0.3 of the Nolo OSVR Fusion Configuration for Ceiling Mode. This configuration uses intelligent sensor fusion and additional filters and settings to get the most out of Nolo hardware when used with the HDK.",
+        "renderManagerConfig": "sample-configs/renderManager.direct.landscape.HDKv2.0.newtracker.json",
+        "display": "displays/OSVR_HDK_2_0.json",
+	"drivers": [
+		/* --- NOLO OSVR FUSION CONFIGURATION v0.3 Drivers --- */
+		{
+		    "plugin": "je_nourish_fusion",
+		    "driver": "FusionDevice",
+		    "params": {
+			"name": "NoloFusedHead",
+			"position": "/NOFC/CeilingHeadTracker",
+			"orientation": {
+			    "roll": "/NOFC/head/roll",
+			    "pitch": "/NOFC/head/pitch",
+			    "yawFast": "/NOFC/head/yaw",
+			    "yawAccurate": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1",
+			// DO NOT EDIT ABOVE THIS LINE
+			    "alpha": 0.9995,
+			// DO NOT EDIT BELOW THIS LINE
+			    "recenterButton": "/NOFC/recenterButton"
+			},
+			"timestamp": "rotation",
+			"flipButton": "/NOFC/flipButton",
+			"flipOrigin": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
+		    }
+		},
+	    {
+		"plugin": "je_nourish_fusion",
+		"driver": "FusionDevice",
+		"params": {
+		    "name": "NoloControllerLeft",
+		    "position": "/NOFC/CeilingLeftControllerTracker",
+		    "orientation": "/com_osvr_Nolo/LYRobotix Nolo/tracker/2",
+		    "flipButton": "/NOFC/flipButton",
+		    "flipOrigin": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
+		}
+	    },
+	    {
+		"plugin": "je_nourish_fusion",
+		"driver": "FusionDevice",
+		"params": {
+		    "name": "NoloControllerRight",
+		    "position": "/NOFC/CeilingRightControllerTracker",
+		    "orientation": "/com_osvr_Nolo/LYRobotix Nolo/tracker/3",
+		    "flipButton": "/NOFC/flipButton",
+		    "flipOrigin": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
+		}
+	    }
+	    /* --- End NOFC Drivers --- */
+	    /* Add a comma after this comment to add more drivers to this config file */
+	],
+	"aliases": {
+		/* --- NOLO OSVR FUSION CONFIGURATION v0.3 Aliases --- */
+		"/NOFC/head/roll": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd", 
+		"/NOFC/head/pitch": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd", 
+	        "/NOFC/head/yaw": "/hdkYawSpace",
+		"/NOFC/flipButton": "/controller/right/menu",
+		"/NOFC/recenterButton": "/controller/right/system",
+
+		"/hdkYawSpace": {
+			"rotate": {
+				"axis": "y",
+				"degrees": -180
+			},
+			"child": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd"
+	        },
+	    
+		"/me/head": "/je_nourish_fusion/NoloFusedHead/tracker/0", 
+		"/me/hands/left": "/je_nourish_fusion/NoloControllerLeft/tracker/0", 
+	        "/me/hands/right": "/je_nourish_fusion/NoloControllerRight/tracker/0", 
+
+	        "/NOFC/CeilingHeadTracker": {
+		    "posttranslate" : [0.0,-0.1,0.1],
+		    "child": {
+			"changeBasis": {
+			    "x" : "x",
+			    "y" : "-z",
+			    "z" : "y"
+			},
+			"child": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
+		    }
+		},
+	    
+	        "/NOFC/CeilingLeftControllerTracker": {
+		    "child": {
+			"changeBasis": {
+			    "x" : "x",
+			    "y" : "-z",
+			    "z" : "y"
+			},
+			"child": "/com_osvr_Nolo/LYRobotix Nolo/tracker/2"
+		    }
+		},
+
+	    	"/NOFC/CeilingRightControllerTracker": {
+		    "child": {
+			"changeBasis": {
+			    "x" : "x",
+			    "y" : "-z",
+			    "z" : "y"
+			},
+			"child": "/com_osvr_Nolo/LYRobotix Nolo/tracker/3"
+		    }
+		}
+
+	    
+		/* --- End NOFC Aliases --- */	
+
+	},
+	"server": {
+		"sleep": 1
+	}
+}

--- a/NOFC/NOFCv0.3_hdk2.direct.json
+++ b/NOFC/NOFCv0.3_hdk2.direct.json
@@ -1,0 +1,83 @@
+{
+	"description": "Version 0.3 of the Nolo OSVR Fusion Configuration. This configuration uses intelligent sensor fusion and additional filters and settings to get the most out of Nolo hardware when used with the HDK.",
+        "renderManagerConfig": "sample-configs/renderManager.direct.landscape.HDKv2.0.newtracker.json",
+        "display": "displays/OSVR_HDK_2_0.json",
+	"drivers": [
+		/* --- NOLO OSVR FUSION CONFIGURATION v0.3 Drivers --- */
+		{
+			"plugin": "je_nourish_fusion",
+			"driver": "FusionDevice",
+			"params": {
+				"name": "NoloFusedHead",
+				"position": "/NOFC/HeadTracker",
+				"orientation": {
+					"roll": "/NOFC/head/roll",
+					"pitch": "/NOFC/head/pitch",
+					"yawFast": "/NOFC/head/yaw",
+					"yawAccurate": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1",
+					"alpha": 0.9995,
+					"recenterButton": "/NOFC/recenterButton"
+				},
+				"timestamp": "rotation",
+				"flipButton": "/NOFC/flipButton",
+				"flipOrigin": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
+			}
+		},
+		{
+			"plugin": "je_nourish_fusion",
+			"driver": "FusionDevice",
+			"params": {
+				"name": "NoloControllerLeft",
+				"position": "/com_osvr_Nolo/LYRobotix Nolo/tracker/2",
+				"orientation": "/com_osvr_Nolo/LYRobotix Nolo/tracker/2",
+				"flipButton": "/NOFC/flipButton",
+				"flipOrigin": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
+			}
+		},
+		{
+			"plugin": "je_nourish_fusion",
+			"driver": "FusionDevice",
+			"params": {
+				"name": "NoloControllerRight",
+				"position": "/com_osvr_Nolo/LYRobotix Nolo/tracker/3",
+				"orientation": "/com_osvr_Nolo/LYRobotix Nolo/tracker/3",
+				"flipButton": "/NOFC/flipButton",
+				"flipOrigin": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
+			}
+		}
+		/* --- End NOFC Drivers --- */
+		/* Add a comma after this comment to add more drivers to this config file */
+	],
+	"aliases": {
+		/* --- NOLO OSVR FUSION CONFIGURATION v0.3 Aliases --- */
+		"/NOFC/head/roll": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd",
+		"/NOFC/head/pitch": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd",
+		"/NOFC/head/yaw": "/hdkYawSpace",
+		"/NOFC/flipButton": "/controller/right/menu",
+		"/NOFC/recenterButton": "/controller/right/system",
+		
+		"/hdkYawSpace": {
+			"rotate": {
+				"axis": "y",
+				"degrees": 0
+			},
+			"child": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd"
+		},	
+		
+		"/me/head": "/je_nourish_fusion/NoloFusedHead/tracker/0",
+		"/me/hands/left": "/je_nourish_fusion/NoloControllerLeft/tracker/0", 
+	        "/me/hands/right": "/je_nourish_fusion/NoloControllerRight/tracker/0",
+
+	    	"/NOFC/HeadTracker": {
+		    "translate" : [0.0,-0.1,0.1],
+		    "child" : "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
+		    }
+		}
+
+		/* --- End NOFC Aliases --- */	
+	},
+	"server": {
+		"sleep": 1
+	}
+
+}

--- a/NOFC/NOFCv0.3_hdk2.distv2.ceiling.json
+++ b/NOFC/NOFCv0.3_hdk2.distv2.ceiling.json
@@ -1,6 +1,5 @@
 {
 	"description": "[Distortion Correction V2 variant] Version 0.3 of the Nolo OSVR Fusion Configuration for Ceiling Mode. This configuration uses intelligent sensor fusion and additional filters and settings to get the most out of Nolo hardware when used with the HDK.",
-	"sleep": 1,
 	"renderManagerConfig": {
 		"meta": {
 			"schemaVersion": 1
@@ -88,7 +87,7 @@
 	    /* Add a comma after this comment to add more drivers to this config file */
 	],
 	"aliases": {
-		/* --- NOLO OSVR FUSION CONFIGURATION v0.2 Aliases --- */
+		/* --- NOLO OSVR FUSION CONFIGURATION v0.3 Aliases --- */
 		"/NOFC/head/roll": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd", 
 		"/NOFC/head/pitch": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd", 
 	        "/NOFC/head/yaw": "/hdkYawSpace",
@@ -108,6 +107,7 @@
 	        "/me/hands/right": "/je_nourish_fusion/NoloControllerRight/tracker/0", 
 
 	        "/NOFC/CeilingHeadTracker": {
+		    "posttranslate" : [0.0,-0.1,0.1],
 		    "child": {
 			"changeBasis": {
 			    "x" : "x",
@@ -142,7 +142,7 @@
 
 	    
 		/* --- End NOFC Aliases --- */	
-		/* Add a comma after this comment to add more aliases to this config file */
+
 	},
 	"server": {
 		"sleep": 1

--- a/NOFC/NOFCv0.3_hdk2.distv2.ceiling.json
+++ b/NOFC/NOFCv0.3_hdk2.distv2.ceiling.json
@@ -1,15 +1,51 @@
 {
-	"description": "Version 0.2 of the Nolo OSVR Fusion Configuration. This configuration uses intelligent sensor fusion and additional filters and settings to get the most out of Nolo hardware when used with the HDK.",
+	"description": "[Distortion Correction V2 variant] Version 0.3 of the Nolo OSVR Fusion Configuration for Ceiling Mode. This configuration uses intelligent sensor fusion and additional filters and settings to get the most out of Nolo hardware when used with the HDK.",
+	"sleep": 1,
+	"renderManagerConfig": {
+		"meta": {
+			"schemaVersion": 1
+		},
+		"renderManagerConfig": {
+			"directModeEnabled": true,
+			"directDisplayIndex": 0,
+			"directHighPriorityEnabled": true,
+			"numBuffers": 2,
+			"verticalSyncEnabled": true,
+			"verticalSyncBlockRenderingEnabled": true,
+			"renderOverfillFactor": 1.2,
+			"renderOversampleFactor": 1,
+			"window": {
+				"title": "OSVR",
+				"fullScreenEnabled": true,
+				"xPosition": 2560,
+				"yPosition": 0
+				},
+			"display": {
+				"rotation": 180,
+				"bitsPerColor": 8
+			},
+			"prediction": {
+				"enabled": true,
+				"staticDelayMS": 26,
+				"leftEyeDelayMS": 0,
+				"rightEyeDelayMS": 0,
+				"localTimeOverride": true
+			},
+			"timeWarp": {
+				"enabled": true,
+				"asynchronous": false,
+				"maxMsBeforeVSync": 5
+			}
+		}
+	},
         "display": "displays/OSVR_HDK_2_0.json",
-        "renderManagerConfig": "sample-configs/renderManager.direct.landscape.HDKv2.0.newtracker.json",
 	"drivers": [
-		/* --- NOLO OSVR FUSION CONFIGURATION v0.2 Drivers --- */
+		/* --- NOLO OSVR FUSION CONFIGURATION v0.3 Drivers --- */
 		{
 		    "plugin": "je_nourish_fusion",
 		    "driver": "FusionDevice",
 		    "params": {
 			"name": "NoloFusedHead",
-			//"position": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1",
 			"position": "/NOFC/CeilingHeadTracker",
 			"orientation": {
 			    "roll": "/NOFC/head/roll",
@@ -31,7 +67,6 @@
 		"driver": "FusionDevice",
 		"params": {
 		    "name": "NoloControllerLeft",
-		    //"position": "/com_osvr_Nolo/LYRobotix Nolo/tracker/2",
 		    "position": "/NOFC/CeilingLeftControllerTracker",
 		    "orientation": "/com_osvr_Nolo/LYRobotix Nolo/tracker/2",
 		    "flipButton": "/NOFC/flipButton",
@@ -43,47 +78,10 @@
 		"driver": "FusionDevice",
 		"params": {
 		    "name": "NoloControllerRight",
-		    //"position": "/com_osvr_Nolo/LYRobotix Nolo/tracker/3",
 		    "position": "/NOFC/CeilingRightControllerTracker",
 		    "orientation": "/com_osvr_Nolo/LYRobotix Nolo/tracker/3",
 		    "flipButton": "/NOFC/flipButton",
 		    "flipOrigin": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
-		}
-	    },
-	    {
-		"plugin": "org_osvr_filter_oneeuro",
-		"driver": "OneEuroFilter",
-		"params": {
-		    "name": "FilteredControllerLeft",
-		    "input": "/je_nourish_fusion/NoloControllerLeft/tracker/0",
-		    "position": {
-			"minCutoff": 1.15,
-			"beta": 0.5,
-			"derivativeCutoff": 1.2
-		    },
-		    "orientation": {
-			"minCutoff": 1.5,
-			"beta": 0.5,
-			"derivativeCutoff": 1.2
-		    }
-		}
-	    },
-	    {
-		"plugin": "org_osvr_filter_oneeuro",
-		"driver": "OneEuroFilter",
-		"params": {
-		    "name": "FilteredControllerRight",
-		    "input": "/je_nourish_fusion/NoloControllerRight/tracker/0",
-		    "position": {
-			"minCutoff": 1.15,
-			"beta": 0.5,
-			"derivativeCutoff": 1.2
-		    },
-		    "orientation": {
-			"minCutoff": 1.5,
-			"beta": 0.5,
-			"derivativeCutoff": 1.2
-		    }
 		}
 	    }
 	    /* --- End NOFC Drivers --- */
@@ -106,8 +104,8 @@
 	        },
 	    
 		"/me/head": "/je_nourish_fusion/NoloFusedHead/tracker/0", 
-		"/me/hands/left": "/org_osvr_filter_oneeuro/FilteredControllerLeft/tracker/0", 
-	        "/me/hands/right": "/org_osvr_filter_oneeuro/FilteredControllerRight/tracker/0", 
+		"/me/hands/left": "/je_nourish_fusion/NoloControllerLeft/tracker/0", 
+	        "/me/hands/right": "/je_nourish_fusion/NoloControllerRight/tracker/0", 
 
 	        "/NOFC/CeilingHeadTracker": {
 		    "child": {

--- a/NOFC/NOFCv0.3_hdk2.distv2.json
+++ b/NOFC/NOFCv0.3_hdk2.distv2.json
@@ -1,5 +1,5 @@
 {
-	"description": "[Distortion Correction V2 variant] Version 0.2 of the Nolo OSVR Fusion Configuration. This configuration uses intelligent sensor fusion and additional filters and settings to get the most out of Nolo hardware when used with the HDK.",
+	"description": "[Distortion Correction V2 variant] Version 0.3 of the Nolo OSVR Fusion Configuration. This configuration uses intelligent sensor fusion and additional filters and settings to get the most out of Nolo hardware when used with the HDK.",
 	"sleep": 1,
 	"renderManagerConfig": {
 		"meta": {
@@ -38,9 +38,9 @@
 			}
 		}
 	},
-	"display": "c:/OSVR/hdk.v2.testdisplay.json",
+        "display": "displays/OSVR_HDK_2_0.json",
 	"drivers": [
-		/* --- NOLO OSVR FUSION CONFIGURATION v0.2 Drivers --- */
+		/* --- NOLO OSVR FUSION CONFIGURATION v0.3 Drivers --- */
 		{
 			"plugin": "je_nourish_fusion",
 			"driver": "FusionDevice",
@@ -81,48 +81,12 @@
 				"flipButton": "/NOFC/flipButton",
 				"flipOrigin": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
 			}
-		},
-		{
-			"plugin": "org_osvr_filter_oneeuro",
-			"driver": "OneEuroFilter",
-			"params": {
-				"name": "FilteredControllerLeft",
-				"input": "/je_nourish_fusion/NoloControllerLeft/tracker/0",
-				"position": {
-					"minCutoff": 1.15,
-					"beta": 0.5,
-					"derivativeCutoff": 1.2
-				},
-				"orientation": {
-					"minCutoff": 1.5,
-					"beta": 0.5,
-					"derivativeCutoff": 1.2
-				}
-			}
-		},
-		{
-			"plugin": "org_osvr_filter_oneeuro",
-			"driver": "OneEuroFilter",
-			"params": {
-				"name": "FilteredControllerRight",
-				"input": "/je_nourish_fusion/NoloControllerRight/tracker/0",
-				"position": {
-					"minCutoff": 1.15,
-					"beta": 0.5,
-					"derivativeCutoff": 1.2
-				},
-				"orientation": {
-					"minCutoff": 1.5,
-					"beta": 0.5,
-					"derivativeCutoff": 1.2
-				}
-			}
 		}
 		/* --- End NOFC Drivers --- */
 		/* Add a comma after this comment to add more drivers to this config file */
 	],
 	"aliases": {
-		/* --- NOLO OSVR FUSION CONFIGURATION v0.2 Aliases --- */
+		/* --- NOLO OSVR FUSION CONFIGURATION v0.3 Aliases --- */
 		"/NOFC/head/roll": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd",
 		"/NOFC/head/pitch": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd",
 		"/NOFC/head/yaw": "/hdkYawSpace",
@@ -138,8 +102,8 @@
         },	
 		
 		"/me/head": "/je_nourish_fusion/NoloFusedHead/tracker/0",
-		"/me/hands/left": "/com_osvr_Nolo/LYRobotix Nolo/tracker/2",
-		"/me/hands/right": "/com_osvr_Nolo/LYRobotix Nolo/tracker/3"
+		"/me/hands/left": "/je_nourish_fusion/NoloControllerLeft/tracker/0", 
+	        "/me/hands/right": "/je_nourish_fusion/NoloControllerRight/tracker/0" 
 		/* --- End NOFC Aliases --- */	
 		/* Add a comma after this comment to add more aliases to this config file */
     }

--- a/NOFC/NOFCv0.3_hdk2.distv2.json
+++ b/NOFC/NOFCv0.3_hdk2.distv2.json
@@ -1,6 +1,5 @@
 {
 	"description": "[Distortion Correction V2 variant] Version 0.3 of the Nolo OSVR Fusion Configuration. This configuration uses intelligent sensor fusion and additional filters and settings to get the most out of Nolo hardware when used with the HDK.",
-	"sleep": 1,
 	"renderManagerConfig": {
 		"meta": {
 			"schemaVersion": 1
@@ -46,7 +45,7 @@
 			"driver": "FusionDevice",
 			"params": {
 				"name": "NoloFusedHead",
-				"position": "/com_osvr_Nolo/LYRobotix Nolo/tracker/1",
+				"position": "/NOFC/HeadTracker",
 				"orientation": {
 					"roll": "/NOFC/head/roll",
 					"pitch": "/NOFC/head/pitch",
@@ -99,12 +98,22 @@
 				"degrees": 0
 			},
 			"child": "/com_osvr_Multiserver/OSVRHackerDevKit0/semantic/hmd"
-        },	
+		},	
 		
 		"/me/head": "/je_nourish_fusion/NoloFusedHead/tracker/0",
 		"/me/hands/left": "/je_nourish_fusion/NoloControllerLeft/tracker/0", 
-	        "/me/hands/right": "/je_nourish_fusion/NoloControllerRight/tracker/0" 
+	        "/me/hands/right": "/je_nourish_fusion/NoloControllerRight/tracker/0",
+
+	    	"/NOFC/HeadTracker": {
+		    "translate" : [0.0,-0.1,0.1],
+		    "child" : "/com_osvr_Nolo/LYRobotix Nolo/tracker/1"
+		    }
+		}
+
 		/* --- End NOFC Aliases --- */	
-		/* Add a comma after this comment to add more aliases to this config file */
-    }
+	},
+	"server": {
+		"sleep": 1
+	}
+
 }


### PR DESCRIPTION
This is a cleanup of the NOFC v0.3 files:
-> OneEuro filter removed
-> In both sets of files NOFC is used for the controllers
-> removed hard-coded path for "display"
-> added the distortion correction to ceiling mode file
-> Updated comments to v0,3 